### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# healthcare_ruby_oe41
+## Related Tickets
+- [#TicketID](https://edu-redmine.sun-asterisk.vn/issues/???)
+
+## WHAT
+- Change number items `completed/total` in admin page.
+
+## HOW
+- I edit js file, inject not_vary_normal items in calculate function.
+
+## WHY
+- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.
+
+## Evidence (Screenshot or Video)


### PR DESCRIPTION
## Related Tickets
- [#TicketID](https://edu-redmine.sun-asterisk.vn/issues/???)

## WHAT
- Change number items `completed/total` in admin page.

## HOW
- I edit js file, inject not_vary_normal items in calculate function.

## WHY
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)